### PR TITLE
Private constructors for utility classes

### DIFF
--- a/src/main/java/net/unit8/wscl/util/DigestUtils.java
+++ b/src/main/java/net/unit8/wscl/util/DigestUtils.java
@@ -42,5 +42,10 @@ public class DigestUtils {
             }
         }
     }
+    
+    private DigestUtils()     //class DigestUtils cannot be instantiated.
+    {
+    	
+    }
 
 }

--- a/src/main/java/net/unit8/wscl/util/FressianUtils.java
+++ b/src/main/java/net/unit8/wscl/util/FressianUtils.java
@@ -24,4 +24,9 @@ public class FressianUtils {
             return Collections.unmodifiableMap(m);
         }
     }
+    
+    private FressianUtils()    //class FressianUtils cannot be instantiated.
+    {
+    	
+    }
 }

--- a/src/main/java/net/unit8/wscl/util/IOUtils.java
+++ b/src/main/java/net/unit8/wscl/util/IOUtils.java
@@ -80,4 +80,9 @@ public class IOUtils {
 
         }
     }
+    
+    private IOUtils()     //class IOUtils cannot be instantiated.
+    {
+    	
+    }
 }

--- a/src/main/java/net/unit8/wscl/util/PropertyUtils.java
+++ b/src/main/java/net/unit8/wscl/util/PropertyUtils.java
@@ -55,4 +55,9 @@ public class PropertyUtils {
         else
             return defaultFile;
     }
+    
+    private PropertyUtils()   //class PropertyUtils cannot be instantiated.
+    {
+    	
+    }
 }


### PR DESCRIPTION
I have added private constructors for utility classes in net.unit8.wscl.util package so that they cannot be instantiated. Please review and verify.
